### PR TITLE
Bugfix/Add instructor serverless installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,25 @@ For reference the workshop labs using this code [can be found here](https://gith
 
 ### Introduction to Serverless
 
-TODO
+#### Instructions
+
+1. Install Serverless Operator from OperatorHub
+
+2. Create the `knative-serving` namespace and apply serving
+
+```
+oc new-project knative-serving
+oc apply -f ./setup/serving.yml
+```
+
+3. Create the 'knative-eventing` namespace and apply eventing
+
+```
+oc new-project knative-eventing
+oc apply -f ./setup/serving.yml
+```
+
+4. Setup Kafka - Follow instructions from `./kafka/README.md`
 
 ### Modernize an Application with Serverless
 

--- a/setup/eventing.yml
+++ b/setup/eventing.yml
@@ -1,0 +1,5 @@
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+    name: knative-eventing
+    namespace: knative-eventing

--- a/setup/serving.yml
+++ b/setup/serving.yml
@@ -1,0 +1,5 @@
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+    name: knative-serving
+    namespace: knative-serving


### PR DESCRIPTION
# Bugfix - Add Serverless Installation Instructions

## What
This PR adds the Serverless installation instructions.

## Why
There will only be one Serverless installation per OpenShift cluster, so need to have participants do it; instead have the instructor do it.

## How
Update `README.md` with serverless installation instructions.

## Who
This content is for the lab instructor.